### PR TITLE
Fix excepion fallthrough sync

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.pgs-soft</groupId>
     <artifactId>HttpClientMock</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/com/pgssoft/httpclient/HttpClientMock.java
+++ b/src/main/java/com/pgssoft/httpclient/HttpClientMock.java
@@ -359,7 +359,13 @@ public final class HttpClientMock extends HttpClient {
         publisher.close();
         try {
             return subscriber.getBody().toCompletableFuture().get();
-        } catch (InterruptedException | ExecutionException e) {
+        } catch (ExecutionException e) {
+            var cause = e.getCause();
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            }
+            throw new RuntimeException("Well, you threw a checked exception when handling the response, now I must wrap it. Blame yourself!", cause);
+        } catch (InterruptedException e) {
             throw new IllegalStateException("Error reading the mocked response body - did you forget to provide it? " +
                     "If there should be no body, try using BodyHandlers.discarding() when making the request", e);
         }

--- a/src/main/java/com/pgssoft/httpclient/HttpClientMock.java
+++ b/src/main/java/com/pgssoft/httpclient/HttpClientMock.java
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
 
 import static com.pgssoft.httpclient.internal.HttpMethods.*;
 
-public final class HttpClientMock extends HttpClient {
+public class HttpClientMock extends HttpClient {
 
     private final Debugger debugger;
     private final List<Rule> rules = new ArrayList<>();
@@ -227,13 +227,13 @@ public final class HttpClientMock extends HttpClient {
         return newRule(PATCH, url);
     }
 
-    private HttpClientMockBuilder newRule(String method) {
+    protected HttpClientMockBuilder newRule(String method) {
         RuleBuilder r = new RuleBuilder(method);
         rulesUnderConstruction.add(r);
         return new HttpClientMockBuilder(r);
     }
 
-    private HttpClientMockBuilder newRule(String method, String url) {
+    protected HttpClientMockBuilder newRule(String method, String url) {
         RuleBuilder r = new RuleBuilder(method, host, url);
         rulesUnderConstruction.add(r);
         return new HttpClientMockBuilder(r);
@@ -348,7 +348,7 @@ public final class HttpClientMock extends HttpClient {
         debuggingOn = false;
     }
 
-    private <T> T submitToBodyHandler(MockedServerResponse serverResponse, HttpResponse.BodyHandler<T> responseBodyHandler) {
+    protected <T> T submitToBodyHandler(MockedServerResponse serverResponse, HttpResponse.BodyHandler<T> responseBodyHandler) {
         var bodyBytes = serverResponse.getBodyBytes();
         var subscriber = responseBodyHandler.apply(produceResponseInfo(serverResponse));
         var publisher = new SubmissionPublisher<List<ByteBuffer>>();
@@ -371,7 +371,7 @@ public final class HttpClientMock extends HttpClient {
         }
     }
 
-    private HttpResponse.ResponseInfo produceResponseInfo(MockedServerResponse response) {
+    protected HttpResponse.ResponseInfo produceResponseInfo(MockedServerResponse response) {
         return new HttpResponse.ResponseInfo() {
             @Override
             public int statusCode() {

--- a/src/test/java/com/pgssoft/httpclient/HttpClientMockExceptionFallthroughTest.java
+++ b/src/test/java/com/pgssoft/httpclient/HttpClientMockExceptionFallthroughTest.java
@@ -1,0 +1,71 @@
+package com.pgssoft.httpclient;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+
+import static java.util.Objects.requireNonNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class HttpClientMockExceptionFallthroughTest {
+
+    @Test
+    void runtimeExceptionShouldFallThroughUnchanged() {
+
+        var httpClientMock = new HttpClientMock();
+
+        httpClientMock.onPost()
+                .withHost("localhost")
+                .withPath("/login")
+                .doReturn(401, "You are not authorized.");
+
+        var client = new LoginClient(httpClientMock);
+
+        assertThrows(ClientSideException.class, () -> client.login());
+    }
+
+    static class ClientSideException extends RuntimeException {
+        public ClientSideException(String message) {
+            super(message);
+        }
+    }
+
+    static class LoginClient {
+
+        private final HttpClient httpClient;
+
+        public LoginClient(HttpClient httpClient) {
+            this.httpClient = requireNonNull(httpClient, "httpClient");
+        }
+
+        public String login() {
+            var uri = URI.create("http://localhost/login");
+            var request = HttpRequest.newBuilder(uri).POST(HttpRequest.BodyPublishers.noBody()).build();
+            try {
+                var response = httpClient.send(request, this::handleBody);
+                return response.body();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        private HttpResponse.BodySubscriber<String> handleBody(HttpResponse.ResponseInfo responseInfo) {
+            var statusCode = responseInfo.statusCode();
+            var readBody = HttpResponse.BodySubscribers.ofString(StandardCharsets.UTF_8);
+            if (statusCode == 200 || statusCode == 204) {
+                return readBody;
+            }
+            return HttpResponse.BodySubscribers.mapping(readBody, message -> {
+                throw new ClientSideException(message);
+            });
+        }
+    }
+}


### PR DESCRIPTION
First of all, thank you for providing this tool as an OSS. Please consider applying my contribution.

I ran into an issue when an exception is thrown from a BodySubscriber, the mock wrappes it incorrectly into multiple exceptions, thus the original exception cannot be asserted properly and conveniently.

I have added a feature test as well, so checking out c25c9673ddf22f3e9d0d06eda9d1d57705527f3e shows how it fails with the unchanged code.

The last commit 549006604e75a1a57a48495a4c6336eb5a48b08d is an absolutely optional suggestion from me to open up the class at least to some extent of inheritance. With this, similar issues could be fixed locally simply by subclassing.