### PR TITLE
Fixed issue when configuring an exception for an asynchronously evaluated request

### DIFF
--- a/src/main/java/com/pgssoft/httpclient/HttpClientMock.java
+++ b/src/main/java/com/pgssoft/httpclient/HttpClientMock.java
@@ -1,7 +1,7 @@
 package com.pgssoft.httpclient;
 
-import com.pgssoft.httpclient.internal.debug.Debugger;
 import com.pgssoft.httpclient.internal.HttpResponseProxy;
+import com.pgssoft.httpclient.internal.debug.Debugger;
 import com.pgssoft.httpclient.internal.rule.Rule;
 import com.pgssoft.httpclient.internal.rule.RuleBuilder;
 
@@ -330,7 +330,9 @@ public final class HttpClientMock extends HttpClient {
             var response = new HttpResponseProxy<>(serverResponse.statusCode(), httpHeaders, body, request);
             return CompletableFuture.completedFuture(response);
         } catch (IOException e) {
-            throw new IllegalStateException(e);
+            var future = new CompletableFuture<HttpResponse<T>>();
+            future.completeExceptionally(e);
+            return future;
         }
 
     }

--- a/src/test/java/com/pgssoft/httpclient/HttpClientMockAsyncTest.java
+++ b/src/test/java/com/pgssoft/httpclient/HttpClientMockAsyncTest.java
@@ -2,6 +2,7 @@ package com.pgssoft.httpclient;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpResponse;
 import java.util.concurrent.ExecutionException;
@@ -9,9 +10,12 @@ import java.util.concurrent.ExecutionException;
 import static java.net.http.HttpRequest.BodyPublishers.noBody;
 import static java.net.http.HttpRequest.newBuilder;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 class HttpClientMockAsyncTest {
+
+    private static final String EXAMPLE_URI = "http://localhost/login";
 
     @Test
     void sendAsync_Should_ReturnCompletedFuture() throws ExecutionException, InterruptedException {
@@ -22,15 +26,32 @@ class HttpClientMockAsyncTest {
                 .withPath("/login")
                 .doReturn(200, "ABC");
 
-        var req = newBuilder(URI.create("http://localhost/login"))
+        var req = newBuilder(URI.create(EXAMPLE_URI))
                 .POST(noBody())
                 .build();
         var res = httpClientMock.sendAsync(req, HttpResponse.BodyHandlers.ofString());
 
         assertThat(res.get().body(), equalTo("ABC"));
         assertThat(res.get().statusCode(), equalTo(200));
-        httpClientMock.verify().post("http://localhost/login");
+        httpClientMock.verify().post(EXAMPLE_URI);
     }
 
+    @Test
+    void sendAsync_Should_ReturnTheConfiguredExceptionInTheCompletedFuture() {
+        HttpClientMock httpClientMock = new HttpClientMock();
+        var expectedException = new IOException("expected exception");
+
+        httpClientMock.onGet(EXAMPLE_URI).doThrowException(expectedException);
+
+        var req = newBuilder(URI.create(EXAMPLE_URI)).GET().build();
+        var res = httpClientMock.sendAsync(req, HttpResponse.BodyHandlers.ofString());
+
+        assertThat(res.isCompletedExceptionally(), is(true));
+        try {
+            res.get();
+        } catch (Exception e) {
+            assertThat(e.getCause(), equalTo(expectedException));
+        }
+    }
 
 }


### PR DESCRIPTION
There was an IllegalStateException thrown instead of returning an exceptionally completed CompletableFuture.